### PR TITLE
Add env-vars-only option

### DIFF
--- a/helpers/template.ts
+++ b/helpers/template.ts
@@ -9,7 +9,8 @@ import fs from "fs";
 import path from "path";
 
 export const ENVIRONMENTS = ["dev", "preview"];
-export const TEMPLATES = ["default", "nextjs-api-routes", "rest-express"];
+export const ENV_VARS_ONLY_TEMPLATE_NAME = "env-vars-only"
+export const TEMPLATES = ["default", "nextjs-api-routes", "rest-express", ENV_VARS_ONLY_TEMPLATE_NAME];
 export type TemplateType = typeof TEMPLATES[number];
 
 export interface InstallEnvArgs {
@@ -57,12 +58,15 @@ export const installEnv = ({
       : "preview"
     : "preview";
 
+  const dotEnvPath = path.join(root, ".env")
   const envContent = `TIGRIS_URI=api.${parsedEnv}.tigrisdata.cloud
 TIGRIS_PROJECT=${project}
 TIGRIS_CLIENT_ID=${clientId}
 TIGRIS_CLIENT_SECRET=${clientSecret}
 TIGRIS_DB_BRANCH=${databaseBranch}`;
-  fs.writeFileSync(path.join(root, ".env"), envContent + os.EOL);
+  fs.writeFileSync(dotEnvPath, envContent + os.EOL);
+
+  return dotEnvPath;
 };
 
 /**


### PR DESCRIPTION
Small suggested change to just create the `.env` file using `npx create-tigris-app`. Potentially needs some refactoring, but pushing for discussion.

https://user-images.githubusercontent.com/328367/214553943-9041a9bf-7324-41e0-be32-d32c71a0412c.mp4

This then updates the console experience to be relevant to people with an existing application. They can run the following for an existing app.

```bash
npx create-tigris-app@latest --project awesome_nextjs_app --client-id <CLIENT_ID> --client-secret <CLIENT_SECRET>
```

We'd need to think through:

* The CLI current creates a directory for the app name. We can just remove that functionality and assume it's for the `cwd` only.
* It clobbers over an existing `.env`. So, we probably want to check if a file exists and append the credentials if they don't already exist. Throw an error if they do already exist.
